### PR TITLE
Deploy to rubygems

### DIFF
--- a/deploy/install-treesitter
+++ b/deploy/install-treesitter
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -ex
+
+PREFIX="$(pwd)/tmp"
+
+mkdir -p tmp/lib tmp/lib
+cd tmp
+
+git clone --depth=1 https://github.com/tree-sitter/tree-sitter.git 2> /dev/null
+cd tree-sitter
+
+make
+PREFIX=$PREFIX make install
+cd ../..
+
+bundle config set build.tree_sitter \
+      --with-tree-sitter-dir=$PREFIX \
+      --with-tree-sitter-lib=$PREFIX/lib \
+      --with-tree-sitter-include=$PREFIX/include \
+      --with-opt-include=$PREFIX/include \
+      --with-opt-lib=$PREFIX/lib

--- a/shipit.production.yml
+++ b/shipit.production.yml
@@ -1,3 +1,3 @@
-deploy:
-  override:
-    - buildkite-trigger tree-stand-publish-package
+dependencies:
+  pre:
+    - ./deploy/install-treesitter


### PR DESCRIPTION
## What

closes #6 

Turns outs the only things missing to be able to build `ruby-tree-sitter` were these bundle config options:

```
--with-opt-include=$PREFIX/include
--with-opt-lib=$PREFIX/lib
```