### PR TITLE
Add missing `ts_node` & `tree` readers to node

### DIFF
--- a/lib/tree_stand/node.rb
+++ b/lib/tree_stand/node.rb
@@ -9,6 +9,11 @@ module TreeStand
 
     def_delegators :@ts_node, :type, :start_byte, :end_byte, :start_point, :end_point
 
+    # @return [TreeStand::Tree]
+    attr_reader :tree
+    # @return [TreeSitter::Node]
+    attr_reader :ts_node
+
     # @api private
     def initialize(tree, ts_node)
       @tree = tree

--- a/lib/tree_stand/version.rb
+++ b/lib/tree_stand/version.rb
@@ -1,4 +1,4 @@
 module TreeStand
   # The current version of the gem.
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/test/unit/node_test.rb
+++ b/test/unit/node_test.rb
@@ -8,6 +8,11 @@ class NodeTest < Minitest::Test
     SQL
   end
 
+  def test_accessors
+    assert_instance_of(TreeSitter::Node, @tree.root_node.ts_node)
+    assert_equal(@tree, @tree.root_node.tree)
+  end
+
   def test_can_enumerate_children
     program = @tree.root_node
     assert_equal(:program, program.type)


### PR DESCRIPTION
## What

The documentation lists that `TreeStand` objects have accessors for the underlying `TreeSitter` versions of those objects. `TreeStand::Node` was missing accessors for `ts_node` & for the parent tree.