### PR TITLE
Implement TreeStand::Node#query

### DIFF
--- a/lib/tree_stand/capture.rb
+++ b/lib/tree_stand/capture.rb
@@ -1,6 +1,7 @@
 module TreeStand
   # Wrapper around a TreeSitter capture.
   # @see TreeStand::Tree#query
+  # @see TreeStand::Node#query
   # @see TreeStand::Match
   class Capture
     # @return [TreeStand::Match]

--- a/lib/tree_stand/tree.rb
+++ b/lib/tree_stand/tree.rb
@@ -26,6 +26,8 @@ module TreeStand
     attr_reader :document
     # @return [TreeSitter::Tree]
     attr_reader :ts_tree
+    # @return [TreeStand::Parser]
+    attr_reader :parser
 
     # @api private
     def initialize(parser, tree, document)
@@ -39,24 +41,12 @@ module TreeStand
       TreeStand::Node.new(self, @ts_tree.root_node)
     end
 
-    # TreeSitter uses a `TreeSitter::Cursor` to iterate over matches by calling
-    # `curser#next_match` repeatedly until it returns `nil`.
-    #
-    # This method does all of that for you and collects them into an array.
-    #
-    # @see TreeStand::Match
-    # @see TreeStand::Capture
-    #
-    # @param query_string [String]
-    # @return [Array<TreeStand::Match>]
+    # (see TreeStand::Node#query)
+    # @note This is a convenience method that calls {TreeStand::Node#query} on
+    #   {#root_node}.
+    # @see TreeStand::Node#query
     def query(query_string)
-      ts_query = TreeSitter::Query.new(@parser.ts_language, query_string)
-      ts_cursor = TreeSitter::QueryCursor.exec(ts_query, @ts_tree.root_node)
-      matches = []
-      while match = ts_cursor.next_match
-        matches << TreeStand::Match.new(self, ts_query, match)
-      end
-      matches
+      root_node.query(query_string)
     end
 
     # This method replaces the section of the document specified by range and

--- a/lib/tree_stand/version.rb
+++ b/lib/tree_stand/version.rb
@@ -1,4 +1,4 @@
 module TreeStand
   # The current version of the gem.
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
# What

Moves the implementation of #query to TreeStand::Node. TreeStand::Tree#query now delegates to TreeStand::Tree#root_node.

```ruby
# This will return a match for each identifier nodes in the tree.
tree_matches = tree.query(<<~QUERY)
  (identifier) @identifier
QUERY

# It is equivalent to:
tree.root_node.query(<<~QUERY)
  (identifier) @identifier
QUERY
```