### PR TITLE
Alias Node#children to Node#to_a

### DIFF
--- a/lib/tree_stand/tree.rb
+++ b/lib/tree_stand/tree.rb
@@ -63,7 +63,7 @@ module TreeStand
       replace_with_new_doc(new_document)
     end
 
-    # This method deletes the section of the document specified by range Then
+    # This method deletes the section of the document specified by range. Then
     # it will reparse the document and update the tree!
     # @param range [TreeStand::Range]
     # @return [void]

--- a/test/unit/node_test.rb
+++ b/test/unit/node_test.rb
@@ -13,6 +13,11 @@ class NodeTest < Minitest::Test
     assert_equal(@tree, @tree.root_node.tree)
   end
 
+  def test_children
+    assert_equal(1, @tree.root_node.children.size)
+    assert_equal(1, @tree.root_node.to_a.size)
+  end
+
   def test_can_enumerate_children
     program = @tree.root_node
     assert_equal(:program, program.type)


### PR DESCRIPTION
## What

`TreeStandNode#each` wasn't intutitive that it iterates over children so I've aliased `to_a` and `children` so that you can write both of these options:

```ruby
node.children.each do |child|
end

node.each do |child|
end
``` 

I've updated the documentation surrounding Node with examples.