### PR TITLE
Node#walk & Tree#each powered by tree walking visitor

### DIFF
--- a/lib/tree_stand/node.rb
+++ b/lib/tree_stand/node.rb
@@ -99,6 +99,24 @@ module TreeStand
       end
     end
 
+    # (see TreeStand::Visitors::TreeWalker)
+    # Backed by {TreeStand::Visitors::TreeWalker}.
+    #
+    # @example Check the subtree for error nodes
+    #   node.walk.any? { |node| node.type == :error }
+    #
+    # @yieldparam node [TreeStand::Node]
+    # @return [Enumerator]
+    #
+    # @see TreeStand::Visitors::TreeWalker
+    def walk(&block)
+      Enumerator.new do |yielder|
+        Visitors::TreeWalker.new(self) do |child|
+          yielder << child
+        end.visit
+      end.each(&block)
+    end
+
     # @example
     #   node.text # => "4"
     #   node.parent.text # => "3 * 4"

--- a/lib/tree_stand/tree.rb
+++ b/lib/tree_stand/tree.rb
@@ -22,6 +22,8 @@ module TreeStand
   # This is not always possible and depends on the edits you make, beware that
   # the tree will be different after each edit and this approach may cause bugs.
   class Tree
+    include Enumerable
+
     # @return [String]
     attr_reader :document
     # @return [TreeSitter::Tree]
@@ -47,6 +49,17 @@ module TreeStand
     # @see TreeStand::Node#query
     def query(query_string)
       root_node.query(query_string)
+    end
+
+    # (see TreeStand::Node#walk)
+    #
+    # @example Includes enumerable methods
+    #   tree.any? { |node| node.type == :error }
+    #
+    # @note This is a convenience method that calls {TreeStand::Node#walk} on
+    #   {#root_node}.
+    def each(&block)
+      root_node.walk(&block)
     end
 
     # This method replaces the section of the document specified by range and

--- a/lib/tree_stand/visitor.rb
+++ b/lib/tree_stand/visitor.rb
@@ -47,7 +47,7 @@ module TreeStand
     def visit_node(node)
       if respond_to?("on_#{node.type}")
         public_send("on_#{node.type}", node)
-      elsif respond_to?(:_on_default)
+      elsif respond_to?(:_on_default, true)
         _on_default(node)
       end
 

--- a/lib/tree_stand/visitors/tree_walker.rb
+++ b/lib/tree_stand/visitors/tree_walker.rb
@@ -1,0 +1,30 @@
+module TreeStand
+  # A collection of useful visitors for traversing trees.
+  module Visitors
+    # Walks the tree depth-first and yields each node to the provided block.
+    #
+    # @example Create a list of all the nodes in the tree.
+    #   list = []
+    #   TreeStand::Visitors::TreeWalker.new(root) do |node|
+    #     list << node
+    #   end.visit
+    #
+    # @see TreeStand::Node#walk
+    # @see TreeStand::Tree#each
+    class TreeWalker < Visitor
+      # @param node [TreeStand::Node]
+      # @param block [Proc] A block that will be called for
+      #   each node in the tree.
+      def initialize(node, &block)
+        super(node)
+        @block = block
+      end
+
+      private
+
+      def _on_default(node)
+        @block.call(node)
+      end
+    end
+  end
+end

--- a/test/unit/visitors/tree_walker_test.rb
+++ b/test/unit/visitors/tree_walker_test.rb
@@ -1,0 +1,70 @@
+require "test_helper"
+
+module Visitors
+  class TreeWalkerTest < Minitest::Test
+    def setup
+      @parser = TreeStand::Parser.new("math")
+      @tree = @parser.parse_string(nil, <<~MATH)
+        1 + x * 3
+      MATH
+    end
+
+    def test_walk_whole_tree
+      node_types = []
+      TreeStand::Visitors::TreeWalker.new(@tree.root_node) do |node|
+        node_types << node.type
+      end.visit
+
+      assert_equal(
+        %i(expression sum number + product variable * number),
+        node_types
+      )
+    end
+
+    def test_walk_the_tree_depth_first
+      tree = @parser.parse_string(nil, <<~MATH)
+        1 + x * 3 + 2
+      MATH
+
+      node_types = []
+      tree.each do |node|
+        node_types << node.type
+      end
+
+      assert_equal(
+        #             double sum nodes show the tree is walked depth-first.
+        #             v
+        %i(expression sum sum number + product variable * number + number),
+        node_types
+      )
+    end
+
+    def test_tree_api_walks_the_whole_tree
+      node_types = []
+      @tree.each do |node|
+        node_types << node.type
+      end
+
+      assert_equal(
+        %i(expression sum number + product variable * number),
+        node_types
+      )
+
+      assert(@tree.any? { |node| node.type == :number })
+    end
+
+    def test_node_api_walks_the_whole_tree
+      node_types = []
+      @tree.root_node.walk do |node|
+        node_types << node.type
+      end
+
+      assert_equal(
+        %i(expression sum number + product variable * number),
+        node_types
+      )
+
+      assert(@tree.root_node.walk.any? { |node| node.type == :number })
+    end
+  end
+end


### PR DESCRIPTION
## What

Having an each way to walk the entire tree (or subtree's) is a common operation. This PR introduces a new `TreeWalker` visitor that allows you to pass a ruby block into the constructor to run logic while walking the whole tree.

* The `Node` class exposes a new `#walk` method as a connivence method for using the TreeWalker visitor.
* `Tree#each` delegates to `root_node.walk`.