### PR TITLE
Support for `pp node` (pretty-printing)

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -3,12 +3,20 @@
 require "bundler/setup"
 require "tree_stand"
 
-# You can add fixtures and/or initialization code here to make experimenting
-# with your gem easier. You can also use a different console, if you like.
+TreeStand.configure do
+  config.parser_path = File.expand_path(
+    File.join(__dir__, "..", "parsers")
+  )
+end
 
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
+ivars_to_add = <<~RUBY
+  @parser = TreeStand::Parser.new("math")
+  @tree = @parser.parse_string(nil, "1 + x")
+RUBY
 
-require "irb"
-IRB.start(__FILE__)
+eval(ivars_to_add)
+puts("available ivars:")
+puts(ivars_to_add)
+
+require "pry"
+Pry.start

--- a/lib/tree_stand/node.rb
+++ b/lib/tree_stand/node.rb
@@ -93,10 +93,12 @@ module TreeStand
     #   node.map(&:text) # => ["3", "*", "4"]
     # @yieldparam child [TreeStand::Node]
     # @return [Enumerator]
-    def each
-      @ts_node.each do |child|
-        yield TreeStand::Node.new(@tree, child)
-      end
+    def each(&block)
+      Enumerator.new do |yielder|
+        @ts_node.each do |child|
+          yielder << TreeStand::Node.new(@tree, child)
+        end
+      end.each(&block)
     end
 
     # (see TreeStand::Visitors::TreeWalker)
@@ -162,6 +164,17 @@ module TreeStand
       range == other.range &&
         type == other.type &&
         text == other.text
+    end
+
+    # (see TreeStand::Utils::Printer)
+    # Backed by {TreeStand::Utils::Printer}.
+    #
+    # @param pp [PP]
+    # @return [void]
+    #
+    # @see TreeStand::Utils::Printer
+    def pretty_print(pp)
+      Utils::Printer.new(ralign: 80).print(self, io: pp.output)
     end
   end
 end

--- a/lib/tree_stand/utils/printer.rb
+++ b/lib/tree_stand/utils/printer.rb
@@ -1,0 +1,70 @@
+module TreeStand
+  # A collection of useful methods for working with syntax trees.
+  module Utils
+    # Used to {TreeStand::Node#pretty_print pretty-print} the node.
+    #
+    # @example
+    #   pp node
+    #   # (expression
+    #   #  (sum
+    #   #   left: (number)              | 1
+    #   #   ("+")                       | +
+    #   #   right: (variable)))         | x
+    class Printer
+      # @param ralign [Integer] the right alignment for the text column.
+      def initialize(ralign:)
+        @ralign = ralign
+      end
+
+      # (see TreeStand::Utils::Printer)
+      #
+      # @param node [TreeStand::Node]
+      # @param io [IO]
+      # @return [IO]
+      def print(node, io: StringIO.new)
+        lines = pretty_output_lines(node)
+
+        lines.each do |line|
+          if line.text.empty?
+            io.puts line.sexpr
+            next
+          end
+
+          io.puts "#{line.sexpr}#{" " * (@ralign - line.sexpr.size)}| #{line.text}"
+        end
+
+        io
+      end
+
+      private
+
+      Line = Struct.new(:sexpr, :text)
+      private_constant :Line
+
+      def pretty_output_lines(node, prefix: "", depth: 0)
+        indent = " " * depth
+        ts_node = node.ts_node
+        if indent.size + prefix.size + ts_node.to_s.size < @ralign || ts_node.child_count == 0
+          return [Line.new("#{indent}#{prefix}#{ts_node}", node.text)]
+        end
+
+        lines = [Line.new("#{indent}#{prefix}(#{ts_node.type}", "")]
+
+        node.each.with_index do |child, index|
+          lines += if field_name = ts_node.field_name_for_child(index)
+            pretty_output_lines(
+              child,
+              prefix: "#{field_name}: ",
+              depth: depth + 1,
+            )
+          else
+            pretty_output_lines(child, depth: depth + 1)
+          end
+        end
+
+        lines.last.sexpr << ")"
+        lines
+      end
+    end
+  end
+end

--- a/test/unit/utils/printer_test.rb
+++ b/test/unit/utils/printer_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+
+module Utils
+  class PrinterTest < Minitest::Test
+    def setup
+      @printer = TreeStand::Utils::Printer.new(ralign: 30)
+      @parser = TreeStand::Parser.new("math")
+    end
+
+    def test_can_print_a_node
+      tree = @parser.parse_string(nil, <<~MATH)
+        1 + x * 3
+      MATH
+
+      assert_equal(<<~SEXPR, @printer.print(tree.root_node).string)
+        (expression
+         (sum
+          left: (number)              | 1
+          ("+")                       | +
+          right: (product
+           left: (variable)           | x
+           ("*")                      | *
+           right: (number))))         | 3
+      SEXPR
+    end
+
+    def test_pretty_printing_nodes
+      tree = @parser.parse_string(nil, <<~MATH)
+        1 + x * 3 + 2 / 4 ** 8 - 9 * (10 - 11.1)
+      MATH
+
+      assert_equal(<<~SEXPR, @printer.print(tree.root_node).string)
+        (expression
+         (subtraction
+          left: (sum
+           left: (sum
+            left: (number)            | 1
+            ("+")                     | +
+            right: (product
+             left: (variable)         | x
+             ("*")                    | *
+             right: (number)))        | 3
+           ("+")                      | +
+           right: (division
+            left: (number)            | 2
+            ("/")                     | /
+            right: (exponent
+             base: (number)           | 4
+             ("**")                   | **
+             exponent: (number))))    | 8
+          ("-")                       | -
+          right: (product
+           left: (number)             | 9
+           ("*")                      | *
+           right: ("(")               | (
+           (subtraction
+            left: (number)            | 10
+            ("-")                     | -
+            right: (number))          | 11.1
+           (")"))))                   | )
+      SEXPR
+    end
+  end
+end


### PR DESCRIPTION
## What

> To define a customized pretty printing function for your classes, redefine method #pretty_print(pp) in the class.
> -- Output Customization (in [Ruby Docs](https://ruby-doc.org/stdlib-3.1.0/libdoc/pp/rdoc/PP.html#class-PP-label-Output+Customization))

This PR adds the `#pretty_print(pp)` method powered by an underlying `Utils::Printer` class to encapsulate the printing logic.

## Other Notes

There's a second commit adding some improvements to `bin/console` into the PR. It runs `TreeStand.configure` and creates a parser & a simple tree to facilitate quick experimentation.