### PR TITLE
Change `tree` param in the parser to be optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ ruby_parser = TreeStand::Parser.new("ruby")
 ### API Conventions
 
 TreeStand aims to provide APIs similar to TreeSitter when possible. For example, the TreeSitter parser exposes a
-`#parse_string(tree, document)` method. TreeStand replicates this behaviour but augments it to return a
-`TreeStand::Tree` instead of the underlying `TreeSitter::Tree`. Similarly, `TreeStand::Tree#root_node` returns a
-`TreeStand::Node` & `TreeSitter::Tree#root_node` returns a `TreeSitter::Node`.
+`#parse_string(tree, document)` method. TreeStand replicates this behaviour closely with it's `#parse_string(document,
+tree: nil)` method but augments it to return a `TreeStand::Tree` instead of the underlying `TreeSitter::Tree`.
+Similarly, `TreeStand::Tree#root_node` returns a `TreeStand::Node` & `TreeSitter::Tree#root_node` returns a
+`TreeSitter::Node`.
 
 The underlying objects are accessible via a `ts_` prefixed attribute, e.g. `ts_parser`, `ts_tree`, `ts_node`, etc.
 

--- a/lib/tree_stand/parser.rb
+++ b/lib/tree_stand/parser.rb
@@ -30,11 +30,13 @@ module TreeStand
     end
 
     # Parse the provided document with the TreeSitter parser.
-    # @param tree [TreeStand::Tree]
+    # @param tree [TreeStand::Tree, nil] providing the old tree will allow the
+    #   parser to take advantage of incremental parsing and improve performance
+    #   by re-useing nodes from the old tree.
     # @param document [String]
     # @return [TreeStand::Tree]
-    def parse_string(tree, document)
-      # There's a bug with passing a non-nil tree
+    def parse_string(document, tree: nil)
+      # @todo There's a bug with passing a non-nil tree
       ts_tree = @ts_parser.parse_string(nil, document)
       TreeStand::Tree.new(self, ts_tree, document)
     end
@@ -45,8 +47,8 @@ module TreeStand
     #
     # @see #parse_string
     # @raise [TreeStand::InvalidDocument]
-    def parse_string!(tree, document)
-      tree = parse_string(tree, document)
+    def parse_string!(document, tree: nil)
+      tree = parse_string(document, tree: tree)
       return tree unless tree.any?(&:error?)
 
       raise(InvalidDocument, <<~ERROR)

--- a/lib/tree_stand/tree.rb
+++ b/lib/tree_stand/tree.rb
@@ -109,7 +109,7 @@ module TreeStand
 
     def replace_with_new_doc(new_document)
       @document = new_document
-      new_tree = @parser.parse_string(@ts_tree, @document)
+      new_tree = @parser.parse_string(@document, tree: self)
       @ts_tree = new_tree.ts_tree
     end
   end

--- a/test/unit/ast_modifier_test.rb
+++ b/test/unit/ast_modifier_test.rb
@@ -6,7 +6,7 @@ class AstModifierTest < Minitest::Test
   end
 
   def test_can_work_with_multiple_edits
-    tree = @parser.parse_string(nil, <<~MATH)
+    tree = @parser.parse_string(<<~MATH)
       1 + x * 3 - x - 2 * 4 + 5
     MATH
 

--- a/test/unit/match_test.rb
+++ b/test/unit/match_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class MatchTest < Minitest::Test
   def setup
     @parser = TreeStand::Parser.new("math")
-    @tree = @parser.parse_string(nil, <<~MATH)
+    @tree = @parser.parse_string(<<~MATH)
       1 + x * 3 + 2
     MATH
   end

--- a/test/unit/node_test.rb
+++ b/test/unit/node_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class NodeTest < Minitest::Test
   def setup
     @parser = TreeStand::Parser.new("math")
-    @tree = @parser.parse_string(nil, <<~MATH)
+    @tree = @parser.parse_string(<<~MATH)
       1 + x * 3
     MATH
   end
@@ -65,7 +65,7 @@ class NodeTest < Minitest::Test
   end
 
   def test_query_for_root_node_returns_the_same_as_query_for_tree
-    tree = @parser.parse_string(nil, <<~MATH)
+    tree = @parser.parse_string(<<~MATH)
       (1 + x) * (2 + 3)
     MATH
 
@@ -87,7 +87,7 @@ class NodeTest < Minitest::Test
   end
 
   def test_query_for_node_returns_only_matches_within_that_node
-    tree = @parser.parse_string(nil, <<~MATH)
+    tree = @parser.parse_string(<<~MATH)
       1 + x * 3 + 2
     MATH
 
@@ -111,7 +111,7 @@ class NodeTest < Minitest::Test
   end
 
   def test_error_nodes
-    tree = @parser.parse_string(nil, <<~MATH)
+    tree = @parser.parse_string(<<~MATH)
       1 ++ x
     MATH
 
@@ -120,7 +120,7 @@ class NodeTest < Minitest::Test
   end
 
   def test_find_node_returns_the_first_node_that_matches_the_query
-    tree = @parser.parse_string(nil, <<~MATH)
+    tree = @parser.parse_string(<<~MATH)
       1 + x * 3 + 2 * 4
     MATH
 

--- a/test/unit/parser_setup_test.rb
+++ b/test/unit/parser_setup_test.rb
@@ -25,7 +25,7 @@ class ParserSetupTest < Minitest::Test
 
   def test_can_parse_a_document_with_tree_stand_api
     parser = TreeStand::Parser.new("math")
-    tree = parser.parse_string(nil, <<~MATH)
+    tree = parser.parse_string( <<~MATH)
       1 + x * 3
     MATH
 
@@ -48,11 +48,11 @@ class ParserSetupTest < Minitest::Test
     MATH
 
 
-    tree = parser.parse_string(nil, document)
+    tree = parser.parse_string(document)
     assert(tree.any?(&:error?))
 
     assert_raises(TreeStand::InvalidDocument) do
-      parser.parse_string!(nil, document)
+      parser.parse_string!(document)
     end
   end
 end

--- a/test/unit/range_test.rb
+++ b/test/unit/range_test.rb
@@ -9,7 +9,7 @@ class RangeTest < Minitest::Test
     document = <<~SQL
       1 + x * 3
     SQL
-    tree = @parser.parse_string(nil, document)
+    tree = @parser.parse_string(document)
 
     range = TreeStand::Range.new(
       start_byte: 0,

--- a/test/unit/tree_test.rb
+++ b/test/unit/tree_test.rb
@@ -7,12 +7,12 @@ class TreeTest < Minitest::Test
 
   def test_text
     document = "1 + x * 3 + 2"
-    tree = @parser.parse_string(nil, document)
+    tree = @parser.parse_string(document)
     assert_equal(document, tree.document)
   end
 
   def test_can_replace_text
-    tree = @parser.parse_string(nil, <<~MATH)
+    tree = @parser.parse_string(<<~MATH)
       1 + x * 3 + 2
     MATH
 
@@ -31,7 +31,7 @@ class TreeTest < Minitest::Test
   end
 
   def test_can_delete_a_node
-    tree = @parser.parse_string(nil, <<~MATH)
+    tree = @parser.parse_string(<<~MATH)
       1 + x * 3 + 2
     MATH
 
@@ -49,7 +49,7 @@ class TreeTest < Minitest::Test
   end
 
   def test_can_handle_invalid_edits
-    tree = @parser.parse_string(nil, <<~MATH)
+    tree = @parser.parse_string(<<~MATH)
       1 + x * 3 + 2
     MATH
 

--- a/test/unit/utils/printer_test.rb
+++ b/test/unit/utils/printer_test.rb
@@ -8,7 +8,7 @@ module Utils
     end
 
     def test_can_print_a_node
-      tree = @parser.parse_string(nil, <<~MATH)
+      tree = @parser.parse_string(<<~MATH)
         1 + x * 3
       MATH
 
@@ -25,7 +25,7 @@ module Utils
     end
 
     def test_pretty_printing_nodes
-      tree = @parser.parse_string(nil, <<~MATH)
+      tree = @parser.parse_string(<<~MATH)
         1 + x * 3 + 2 / 4 ** 8 - 9 * (10 - 11.1)
       MATH
 

--- a/test/unit/visitor_test.rb
+++ b/test/unit/visitor_test.rb
@@ -6,7 +6,7 @@ class VisitorTest < Minitest::Test
   end
 
   def test_on_default
-    tree = @parser.parse_string(nil, <<~MATH)
+    tree = @parser.parse_string(<<~MATH)
       1 + x * 3
     MATH
 
@@ -23,7 +23,7 @@ class VisitorTest < Minitest::Test
   end
 
   def test_custom_visitor_hooks
-    tree = @parser.parse_string(nil, <<~MATH)
+    tree = @parser.parse_string(<<~MATH)
       1 + x * 3
     MATH
 

--- a/test/unit/visitors/tree_walker_test.rb
+++ b/test/unit/visitors/tree_walker_test.rb
@@ -4,7 +4,7 @@ module Visitors
   class TreeWalkerTest < Minitest::Test
     def setup
       @parser = TreeStand::Parser.new("math")
-      @tree = @parser.parse_string(nil, <<~MATH)
+      @tree = @parser.parse_string(<<~MATH)
         1 + x * 3
       MATH
     end
@@ -22,7 +22,7 @@ module Visitors
     end
 
     def test_walk_the_tree_depth_first
-      tree = @parser.parse_string(nil, <<~MATH)
+      tree = @parser.parse_string(<<~MATH)
         1 + x * 3 + 2
       MATH
 


### PR DESCRIPTION
## What

> Just updating to the latest tree_stand version. I think this is another area where we are following the treesitter api a little too closely. What would you think about changing the method signature to:
> `#parse_string(text, tree: nil)`
> -- @phsurette 

This PR addresses your feedback @phsurette. I also updated the README example to show subtle change to the API.
