### PR TITLE
Use `ruby_tree_sitter` gem published to rubygems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,10 @@ jobs:
         entry:
           - { ruby: 3.0 }
           - { ruby: 3.1 }
+          - { ruby: 3.2 }
     name: test (${{ matrix.entry.ruby }})
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions/checkout@v3
-        with:
-          repository: DerekStride/tree-sitter-sql
-          path: tmp/tree-sitter-sql
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -33,12 +29,7 @@ jobs:
           key: ${{ runner.os }}-gems-${{ hashFiles('Gemfile') }}
           restore-keys: ${{ runner.os }}-gems-
 
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-      - run: npm install tree-sitter-cli
-
-      - run: sudo apt-get install -y libtree-sitter-dev make gcc
+      - run: sudo apt-get install -y libtree-sitter-dev
       - run: bundle install --jobs=3 --retry=3 --path=vendor/bundle
       - run: bin/setup
       - run: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,15 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'tree_sitter', git: 'https://github.com/Faveod/ruby-tree-sitter'
+group :development, :test do
+  gem "bundler", "~> 2.3"
+  gem "rake", "~> 13.0"
+  gem "pry-byebug", "~> 3.10"
+  gem "yard", "~> 0.9.28"
+end
+
+group :test do
+  gem "minitest", "~> 5.17"
+  gem "minitest-reporters", "~> 1.5"
+  gem "minitest-focus", "~> 1.3"
+end

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ See the [documentation](https://shopify.github.io/tree_stand) for supported feat
 
 ### Setting Up a Parser
 
-TreeStand do not help with compiling individual parsers. However, once you compile a parser and generate a shared
+TreeStand does not help with compiling individual parsers. However, once you compile a parser and generate a shared
 object (`.so`) or a dynamic library (`.dylib`) you can tell TreeStand where to find them and pass the parser filename
 to `TreeStand::Parser::new`.
 

--- a/bin/setup
+++ b/bin/setup
@@ -13,7 +13,6 @@ fi
 
 cd tmp/tree-sitter-math
 
-npm install
 mkdir -p target
 gcc -shared -o target/parser.so -fPIC src/parser.c -I./src
 

--- a/tree_stand.gemspec
+++ b/tree_stand.gemspec
@@ -29,13 +29,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "ruby_tree_sitter"
   spec.add_dependency "zeitwerk"
-
-  spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "minitest"
-  spec.add_development_dependency "minitest-reporters"
-  spec.add_development_dependency "minitest-focus"
-  spec.add_development_dependency "pry-byebug"
-  spec.add_development_dependency "yard"
 end


### PR DESCRIPTION
## What

With https://github.com/Faveod/ruby-tree-sitter/issues/23 now closed we can point to the proper dependency published to rubygems and make it a part of the spec.

It's also best practice to list the development & test gems in the Gemfile instead of the gemspec so I've move those over.

I'll cut a new version after this change.