### PR TITLE
fix(pretty-print): PP#output responds to #<<, use in `Utils::Printer`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,8 @@ gemspec
 
 group :development, :test do
   gem "bundler", "~> 2.3"
+  gem "debug", "~> 1.7", require: false
   gem "rake", "~> 13.0"
-  gem "pry-byebug", "~> 3.10"
   gem 'tapioca', "~> 0.11.1", require: false
   gem "yard", "~> 0.9.28"
 end

--- a/bin/console
+++ b/bin/console
@@ -11,12 +11,12 @@ end
 
 ivars_to_add = <<~RUBY
   @parser = TreeStand::Parser.new("math")
-  @tree = @parser.parse_string(nil, "1 + x")
+  @tree = @parser.parse_string("1 + x")
 RUBY
 
 eval(ivars_to_add)
 puts("available ivars:")
 puts(ivars_to_add)
 
-require "pry"
-Pry.start
+require "irb"
+IRB.start(__FILE__)

--- a/lib/tree_stand.rb
+++ b/lib/tree_stand.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 # typed: true
 
+require "forwardable"
 require "sorbet-runtime"
+require "stringio"
 require "tree_sitter"
 require "zeitwerk"
 

--- a/lib/tree_stand/utils/printer.rb
+++ b/lib/tree_stand/utils/printer.rb
@@ -23,17 +23,17 @@ module TreeStand
       end
 
       # (see TreeStand::Utils::Printer)
-      sig { params(node: TreeStand::Node, io: T.any(IO, StringIO)).returns(T.any(IO, StringIO)) }
+      sig { params(node: TreeStand::Node, io: T.any(IO, StringIO, String)).returns(T.any(IO, StringIO, String)) }
       def print(node, io: StringIO.new)
         lines = pretty_output_lines(node)
 
         lines.each do |line|
           if line.text.empty?
-            io.puts line.sexpr
+            io << line.sexpr << "\n"
             next
           end
 
-          io.puts "#{line.sexpr}#{" " * (@ralign - line.sexpr.size)}| #{line.text}"
+          io << "#{line.sexpr}#{" " * (@ralign - line.sexpr.size)}| #{line.text}\n"
         end
 
         io

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,6 @@
 require "bundler/setup"
 require "tree_stand"
-require "pry-byebug" if ENV["PRY"]
+require "debug"
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/reporters"

--- a/test/unit/utils/printer_test.rb
+++ b/test/unit/utils/printer_test.rb
@@ -24,6 +24,20 @@ module Utils
       SEXPR
     end
 
+    def test_printer_accepts_a_string
+      tree = @parser.parse_string(<<~MATH)
+        1 + x
+      MATH
+
+      assert_equal(<<~SEXPR, @printer.print(tree.root_node, io: +""))
+        (expression
+         (sum
+          left: (number)              | 1
+          ("+")                       | +
+          right: (variable)))         | x
+      SEXPR
+    end
+
     def test_pretty_printing_nodes
       tree = @parser.parse_string(<<~MATH)
         1 + x * 3 + 2 / 4 ** 8 - 9 * (10 - 11.1)


### PR DESCRIPTION
## What

An error would be raised when inspecting a `TreeStand::Node` from the `IRB` console or the REPL from the [`debug`](https://github.com/ruby/debug/pull/958) gem.

```
➜ tree-stand bin/console
available ivars:
@parser = TreeStand::Parser.new("math")
@tree = @parser.parse_string("1 + x")
>> @tree.root_node
An error occurred when inspecting the object: #<NoMethodError: private method `puts' called for "":String>
Result of Kernel#inspect: #<TreeStand::Node:0x0000000108015fa0 @tree=#<TreeStand::Tree:0x0000000104d52960 @parser=#<TreeStand::Parser:0x0000000107d651e8 @language_string="math", @ts_language=#<TreeSitter::Language:0x0000000107d63f50>, @ts_parser=#<TreeSitter::Parser:0x0000000107d63ed8>>, @ts_tree=#<TreeSitter::Tree:0x00000001051058f0>, @document="1 + x">, @ts_node=(expression (sum left: (number) right: (variable))), @fields=[]>
```

## Fix

From the documentation of the [`PrettyPrint#output`](https://ruby-doc.org/3.2.2/stdlibs/prettyprint/PrettyPrint.html) attribute. The only method it's expected to respond to is `#<<`. Both `IRB` & `debug` were passing String's which does legitimately respond to `#<<`.

I've updated the `Utils::Printer#print` method to accept a String object and use the `#<<` method instead of `#puts`.

## Additional Notes

This PR switches the project to use the `ruby/debug` & `IRB`.