### PR TITLE
Prepare v0.2.0 for release

### DIFF
--- a/lib/tree_stand/version.rb
+++ b/lib/tree_stand/version.rb
@@ -3,5 +3,5 @@
 
 module TreeStand
   # The current version of the gem.
-  VERSION = "0.1.6"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
## What

I'm bumping us to `v0.2.0` since #24 changed the `_on_default` hook for `on` which is a breaking change to the public API.