### PR TITLE
Add `required_ruby_version`

### DIFF
--- a/tree_stand.gemspec
+++ b/tree_stand.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/Shopify/tree_stand"
   spec.license       = "MIT"
 
+  spec.required_ruby_version = ">= 3.0.0"
+
   spec.metadata = {
     "allowed_push_host" => "https://rubygems.org",
     "homepage_uri" => spec.homepage,


### PR DESCRIPTION
## What

fixes https://github.com/Shopify/tree_stand/issues/27

This will update the [rubygems page](https://rubygems.org/gems/tree_stand) to indicate that ruby 3 or greater is required to use the gem.